### PR TITLE
Adding version number to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,6 @@
 	"documentation": "https://www.home-assistant.io/integrations/rdw",
 	"domain": "rdw",
 	"name": "RDW",
-	"requirements": ["sodapy==2.0.0"]
+	"requirements": ["sodapy==2.0.0"],
+  	"version": "2.9.7"
 }
-


### PR DESCRIPTION
Fixes warning:
```
2021-03-04 11:35:05 WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'rdw'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'rdw'
```