### PR TITLE
Error Fix: 'device_state_attributes' is now deprecated

### DIFF
--- a/custom_components/home-assistant-rdw/binary_sensor.py
+++ b/custom_components/home-assistant-rdw/binary_sensor.py
@@ -88,7 +88,7 @@ class RDWBinarySensor(Entity):
         return self._available
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
 
         # Set default attribution

--- a/custom_components/home-assistant-rdw/sensor.py
+++ b/custom_components/home-assistant-rdw/sensor.py
@@ -85,7 +85,7 @@ class RDWSensor(Entity):
         return result
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
 
         # Set default attribution


### PR DESCRIPTION
Fix for error: `device_state_attributes` is deprecated. 
Replace with `extra_state_attributes`.

Development page: [https://developers.home-assistant.io/docs/dev_101_states/](https://developers.home-assistant.io/docs/dev_101_states/)

Error log: `(<class 'custom_components.rdw.sensor.RDWSensor'>) implements device_state_attributes. Please report it to the custom component author.`